### PR TITLE
fix paths + rename tests

### DIFF
--- a/src/functions/MulWad.sol
+++ b/src/functions/MulWad.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./utils/Constants.sol";
+import "../utils/Constants.sol";
 
 contract MulWad is Constants {
     function solmateMulWadDown(uint256 x, uint256 y) public pure returns (uint256 z) {

--- a/src/functions/MulWadUp.sol
+++ b/src/functions/MulWadUp.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./utils/Constants.sol";
+import "../utils/Constants.sol";
 
 contract MulWadUp is Constants {
     function solmateMulWadUp(uint256 x, uint256 y) public pure returns (uint256 z) {

--- a/src/functions/PowWad.sol
+++ b/src/functions/PowWad.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./utils/Constants.sol";
+import "../utils/Constants.sol";
 
 contract PowWad is Constants {
     /// @dev Equivalent to `x` to the power of `y`.

--- a/test/MulWad.t.sol
+++ b/test/MulWad.t.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
-import "../src/MulWad.sol";
+import "../src/functions/MulWad.sol";
 
 // Halmos is able to handle this one exactly as-is.
 
 // To run:
-// - `halmos --function test__MulWadCorrectnessAndEquivalence` (proves correctness of both implementations and equivalence)
+// - `halmos --function testCheck__MulWadCorrectnessAndEquivalence` (proves correctness of both implementations and equivalence)
 
 contract MulWadTests is Test {
     MulWad c;
@@ -17,7 +17,7 @@ contract MulWadTests is Test {
     }
 
     // Fuzz test to check that both mulWad functions appear to be correct.
-    function test__MulWadCorrectnessAndEquivalence(uint128 _x, uint128 _y) public {
+    function testCheck__MulWadCorrectnessAndEquivalence(uint128 _x, uint128 _y) public {
         uint x = uint(_x);
         uint y = uint(_y);
 

--- a/test/MulWadUp.t.sol
+++ b/test/MulWadUp.t.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
-import "../src/MulWadUp.sol";
+import "../src/functions/MulWadUp.sol";
 
 // Halmos isn't able to prove the correctness, because the math to get the correct value in pure Solidity is too complex.
 // So we prove the correctness with a fuzz test and then prove the equivalence of the two full functions with Halmos.
 
 // To run:
 // - `forge test --match test__MulWadUpCorrectness` (fuzz for correctness of both versions)
-// - `halmos --function test__MulWadUpEquivalence` (proves equivalence of two implementations)
+// - `halmos --function testCheck__MulWadUpEquivalence` (proves equivalence of two implementations)
 
 contract MulWadUpTests is Test {
     MulWadUp c;
@@ -36,7 +36,7 @@ contract MulWadUpTests is Test {
     }
 
     // Symbolic test to confirm that the two functions result in same output.
-    function test__MulWadUpEquivalence(uint128 _x, uint128 _y) public {
+    function testCheck__MulWadUpEquivalence(uint128 _x, uint128 _y) public {
         uint x = uint(_x);
         uint y = uint(_y);
 

--- a/test/Sqrt.t.sol
+++ b/test/Sqrt.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
-import "../src/Sqrt.sol";
+import "../src/functions/Sqrt.sol";
 
 // All differences between the two implementations exist in the first half of the function,
 // so we abstract out the final (identical) piece, to leave just the differences.
@@ -13,7 +13,7 @@ import "../src/Sqrt.sol";
 
 // To run:
 // - `forge test --match test__SqrtCorrectness` (fuzz for correctness of both versions)
-// - `halmos --function test__SqrtEquivalence` (symbolic test of equivalence)
+// - `halmos --function testCheck__SqrtEquivalence` (symbolic test of equivalence)
 
 contract SqrtTests is Test {
     Sqrt c;
@@ -35,7 +35,8 @@ contract SqrtTests is Test {
     }
 
     // Symbolic test to confirm that the differences between two functions result in same output.
-    function test__SqrtEquivalence(uint x) public {
+    /// @custom:halmos --solver-timeout-assertion 0
+    function testCheck__SqrtEquivalence(uint x) public {
         uint solmate = c.solmateSqrtStripped(x);
         uint solady = c.soladySqrtStripped(x);
         assertEq(solmate, solady);

--- a/test/drafts/PowWad.t.sol
+++ b/test/drafts/PowWad.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
-import "src/PowWad.sol";
+import "../../src/functions/PowWad.sol";
 
 // This one doesn't work for Halmos because it requires SIGNEXTEND op code, which isn't implemented yet.
 


### PR DESCRIPTION
rename symbolic tests so that `halmos --function testCheck` can run all the symbolic tests at once.