### PR TITLE
formally verify Solady log2 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each function has a separate test in `test/`. Some tests are written for Foundry
 - [x] sqrt
 - [x] mulWad
 - [x] mulWadUp
+- [x] log2 
 - [ ] divWad
 - [ ] divWadUp
 - [ ] mulDivDown
@@ -53,3 +54,10 @@ To run:
 - `halmos --function test__MulWadUpEquivalence` (proves equivalence of two implementations)
 
 Explanation: Halmos isn't able to prove the correctness, because the math to get the correct value in pure Solidity is too complex. So we prove the correctness with a fuzz test and then prove the equivalence of the two full functions with Halmos.
+
+### ✅ log2()
+
+To run:
+- `halmos --match-test Log2 --loop 256 --function test` (symbolic test of equivalence)
+
+Explanation: The Solady code is verified to be correct by definition. The definition of log2 is the most significant bit that is set to 1. This test proves the equivalence between the Solady code and (much less efficient but simple code) that loops over the bits and returns the index of the most significant one. Note that that log2(0) is undefined, but the code returns 0 for that case. Because the reference code uses a for loop, we need to explicitly tell Halmos to unwrap the loop 256 times to ensure the code paths are fully explored.

--- a/src/functions/Log2.sol
+++ b/src/functions/Log2.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Log2 {
+
+    // Code that is correct -- log2 is the most significant 1 bit 
+    // Note: log2(0) returns 0 instead of reverting
+    function correctLog2(uint256 x) public pure returns (uint256 r) {
+        for(r = 255; r >= 0; r--) {
+            if (x >> r & uint256(1) == 1) {
+                break;
+            }
+        }
+    }
+
+    function soladyLog2(uint256 x) public pure returns (uint256 r) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            r := shl(7, lt(0xffffffffffffffffffffffffffffffff, x))
+            r := or(r, shl(6, lt(0xffffffffffffffff, shr(r, x))))
+            r := or(r, shl(5, lt(0xffffffff, shr(r, x))))
+            r := or(r, shl(4, lt(0xffff, shr(r, x))))
+            r := or(r, shl(3, lt(0xff, shr(r, x))))
+            // forgefmt: disable-next-item
+            r := or(r, byte(and(0x1f, shr(shr(r, x), 0x8421084210842108cc6318c6db6d54be)),
+                0x0706060506020504060203020504030106050205030304010505030400000000))
+        }
+    }
+}

--- a/test/Log2.sol
+++ b/test/Log2.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../src/functions/Log2.sol";
+
+// Halmos is able to handle this one exactly as-is.
+
+// To run:
+// - `halmos --match-test Log2 --loop 256 --function test` (proves that Solady log 2 matches the definition)
+
+contract Log2Tests is Test {
+    Log2 c;
+
+    function setUp() public {
+        c = new Log2();
+    }
+
+    // Check that Solady Log2 matches the definition solution 
+    function testCheck__Log2Equivalence(uint256 x) public {
+
+        uint correct = c.correctLog2(x);
+        uint solady = c.soladyLog2(x);
+
+        assertEq(correct, solady);
+    }
+}


### PR DESCRIPTION
This pull request formally verifies the Solady log2 implementation by proving its equivalence to a for loop that returns the most significant bit.